### PR TITLE
add ingress to argocd

### DIFF
--- a/overlays/prod/argocd/ingress.yaml
+++ b/overlays/prod/argocd/ingress.yaml
@@ -1,0 +1,20 @@
+# create ingress for argocd
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-ingress
+  namespace: argocd
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /argocd(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: argocd-server
+            port:
+              number: 443


### PR DESCRIPTION
## Why

- By default, argocd does not have ingress because ingress is optional in k8s.

## What

- Add ingress to argocd so that we can see argocd without port-forwarding.

## QA

- [ ] I checked this
